### PR TITLE
Fix issue #7 - Using 'Block IP Address' automatically disconnects the next person

### DIFF
--- a/javascript/modules/ip-handling.js
+++ b/javascript/modules/ip-handling.js
@@ -393,7 +393,9 @@ const IPBlockingManager = {
                 VideoFilterManager.sendErrorMessage(
                     `Blocked the IP address ${unhashedAddress}${ChatRegistry.isChatting() ? " and skipped the current chat" : ""}`
                 ).appendChild(ButtonManager.ipUnblockButton(unhashedAddress));
-                AutoSkipManager.skipIfPossible();
+                if (ChatRegistry.isChatting()) {
+                    AutoSkipManager.skipIfPossible();
+                }
             } else {
                 alert(`The IP address ${unhashedAddress} is already blocked in video chat!`)
             }


### PR DESCRIPTION
The problem was caused by not checking if the user is connected to chat, and directly trying to disconnect. A simple if condition was added in this pull  request.

This PR solves the issue #7 