### PR TITLE
Remove reconnect block for video

### DIFF
--- a/javascript/modules/auto-reconnect.js
+++ b/javascript/modules/auto-reconnect.js
@@ -2,8 +2,6 @@ const ReconnectManager = {
     initialize: () => ReconnectManager._chatEnded(),
     _chatEnded() {
         document.addEventListener("chatEnded", (event) => {
-            if (event["detail"]["isVideoChat"]) return;
-
 
             let reconnectQuery = {};
             reconnectQuery[config.autoReconnectToggle.getName()] = config.autoReconnectToggle.getDefault();


### PR DESCRIPTION
Sometime after December 7, 2022, Omegle removed the auto-reconnect feature for video chat. This change enables it again!